### PR TITLE
Changing auto_ptr to unique_ptr to avoid warnings

### DIFF
--- a/src/VALfiles/Proposition.cpp
+++ b/src/VALfiles/Proposition.cpp
@@ -3005,8 +3005,8 @@ void QfiedGoal::write(ostream & o) const
 	for(var_symbol_list::const_iterator i = qf->getVars()->begin();i != qf->getVars()->end();++i)
 	{
 	*/
-	auto_ptr<WriteController> w(parse_category::recoverWriteController());
-	auto_ptr<WriteController> p(new PrettyPrinter());
+	unique_ptr<WriteController> w(parse_category::recoverWriteController());
+	unique_ptr<WriteController> p(new PrettyPrinter());
 	parse_category::setWriteController(p);
   o<< *qg << "\n";
   	parse_category::setWriteController(w);

--- a/src/VALfiles/Relax.cpp
+++ b/src/VALfiles/Relax.cpp
@@ -107,8 +107,8 @@ int main(int argc,char * argv[])
 
 	    // Output syntax tree
 	    dyna = new RelaxTranslator(current_analysis);
-	    auto_ptr<WriteController> ts 
-	    		= auto_ptr<WriteController>(dyna);
+	    unique_ptr<WriteController> ts 
+	    		= unique_ptr<WriteController>(dyna);
 	    // NOTE: We pass responsibility for dyna into parse_category. There
 	    // is no need to garbage collect it. BUT we access dyna later through
 	    // this pointer, so beware!

--- a/src/VALfiles/RepairAdvice.cpp
+++ b/src/VALfiles/RepairAdvice.cpp
@@ -50,7 +50,7 @@
 
 namespace VAL {
   
-auto_ptr<UnsatConditionFactory> ErrorLog::fac(new UnsatConditionFactory);
+unique_ptr<UnsatConditionFactory> ErrorLog::fac(new UnsatConditionFactory);
 
 string UnsatCondition::getAdviceString() const
 {

--- a/src/VALfiles/RepairAdvice.h
+++ b/src/VALfiles/RepairAdvice.h
@@ -52,7 +52,7 @@
 #include <memory>
 
 
-using std::auto_ptr;
+using std::unique_ptr;
 
 namespace VAL {
   
@@ -198,19 +198,19 @@ virtual MutexViolation *
 
 class ErrorLog {
 private:
-  static auto_ptr<UnsatConditionFactory> fac;
+  static unique_ptr<UnsatConditionFactory> fac;
   
   vector<const UnsatCondition *> conditions; 
 public:
   template<typename Fac>
   static void replace() { 
-  	auto_ptr<Fac> f(new Fac);
+  	unique_ptr<Fac> f(new Fac);
   	fac = f;
   };
   template<typename Fac>
   static void replace(Fac * f)
   {
-  	auto_ptr<Fac> nf(f);
+  	unique_ptr<Fac> nf(f);
   	fac = nf;
   };
   ErrorLog() {};

--- a/src/VALfiles/TIM.cpp
+++ b/src/VALfiles/TIM.cpp
@@ -79,8 +79,8 @@ void performTIMAnalysis(char * argv[])
     current_analysis->const_tab.replaceFactory<TIMobjectSymbol>();
     current_analysis->op_tab.replaceFactory<TIMactionSymbol>();
     current_analysis->setFactory(new TIMfactory());
-    auto_ptr<EPSBuilder> eps(new specEPSBuilder<TIMpredSymbol>());
-    Associater::buildEPS = eps;
+    unique_ptr<EPSBuilder> eps(new specEPSBuilder<TIMpredSymbol>());
+    Associater::buildEPS = std::move(eps);
     
     ifstream* current_in_stream;
     yydebug=0; // Set to 1 to output yacc trace 

--- a/src/VALfiles/TypeStrip.cpp
+++ b/src/VALfiles/TypeStrip.cpp
@@ -105,8 +105,8 @@ int main(int argc,char * argv[])
 	    yyparse();
 
 	    // Output syntax tree
-	    auto_ptr<WriteController> ts 
-	    		= auto_ptr<WriteController>(new TypeStripWriteController(current_analysis));
+	    unique_ptr<WriteController> ts 
+	    		= unique_ptr<WriteController>(new TypeStripWriteController(current_analysis));
 	    parse_category::setWriteController(ts);
 	    if (top_thing) 
 		{

--- a/src/VALfiles/TypedAnalyser.cpp
+++ b/src/VALfiles/TypedAnalyser.cpp
@@ -141,7 +141,7 @@ vector<double> extended_pred_symbol::getTimedAchievers(Environment * f,const pro
 PropInfoFactory * PropInfoFactory::pf = 0;
 
 
-auto_ptr<EPSBuilder> Associater::buildEPS(new EPSBuilder());
+unique_ptr<EPSBuilder> Associater::buildEPS(new EPSBuilder());
 
 // Associater associates predicates with their various type-specific versions.
 // So, if a predicate is overloaded to work with multiple types this will store

--- a/src/VALfiles/TypedAnalyser.h
+++ b/src/VALfiles/TypedAnalyser.h
@@ -865,7 +865,7 @@ struct specEPSBuilder : public EPSBuilder {
 
 class Associater {
 public:
-	static auto_ptr<EPSBuilder> buildEPS;
+	static unique_ptr<EPSBuilder> buildEPS;
 	virtual ~Associater() {};
 	virtual Associater * lookup(pddl_type * p)
 	{

--- a/src/VALfiles/instantiation.cpp
+++ b/src/VALfiles/instantiation.cpp
@@ -1744,7 +1744,7 @@ void instantiatedOp::instantiate(const VAL::operator_ * op, const VAL::problem *
         }
     }
 
-    auto_ptr<PDCIterator> options(pdc.getIterator());
+    unique_ptr<PDCIterator> options(pdc.getIterator());
 
     while (options->isValid()) {
         for (int x = 0; x < opParamCount; ++x) {

--- a/src/VALfiles/misc/DYNA.cpp
+++ b/src/VALfiles/misc/DYNA.cpp
@@ -107,8 +107,8 @@ int main(int argc,char * argv[])
 
 	    // Output syntax tree
 	    dyna = new DYNATranslator(current_analysis);
-	    auto_ptr<WriteController> ts 
-	    		= auto_ptr<WriteController>(dyna);
+	    unique_ptr<WriteController> ts 
+	    		= unique_ptr<WriteController>(dyna);
 	    // NOTE: We pass responsibility for dyna into parse_category. There
 	    // is no need to garbage collect it. BUT we access dyna later through
 	    // this pointer, so beware!

--- a/src/VALfiles/misc/LPGP.cpp
+++ b/src/VALfiles/misc/LPGP.cpp
@@ -107,8 +107,8 @@ int main(int argc,char * argv[])
 
 	    // Output syntax tree
 	    lpgp = new LPGPTranslator(current_analysis);
-	    auto_ptr<WriteController> ts 
-	    		= auto_ptr<WriteController>(lpgp);
+	    unique_ptr<WriteController> ts 
+	    		= unique_ptr<WriteController>(lpgp);
 	    // NOTE: We pass responsibility for lpgp into parse_category. There
 	    // is no need to garbage collect it. BUT we access lpgp later through
 	    // this pointer, so beware!

--- a/src/VALfiles/parsing/ptree.cpp
+++ b/src/VALfiles/parsing/ptree.cpp
@@ -52,14 +52,14 @@
 
 namespace VAL {
 
-auto_ptr<WriteController> parse_category::wcntr = auto_ptr<WriteController>(new DebugWriteController);
+unique_ptr<WriteController> parse_category::wcntr = unique_ptr<WriteController>(new DebugWriteController);
 
 WriteController * parse_category::recoverWriteController()
 {
 	return wcntr.release();
 };
 
-void parse_category::setWriteController(auto_ptr<WriteController> w) {wcntr = w;};
+void parse_category::setWriteController(unique_ptr<WriteController>& w) {wcntr = std::move(w);};
 
 void parse_category::display(int ind) const
 {

--- a/src/VALfiles/parsing/ptree.h
+++ b/src/VALfiles/parsing/ptree.h
@@ -69,7 +69,7 @@ using std::list;
 using std::map;
 using std::cout;
 using std::string;
-using std::auto_ptr;
+using std::unique_ptr;
 using std::ostream;
 
 namespace VAL {
@@ -218,14 +218,14 @@ extern analysis* current_analysis;
 class parse_category
 {
 protected:
-	static auto_ptr<WriteController> wcntr;
+	static unique_ptr<WriteController> wcntr;
 public:
     parse_category() {};
     virtual ~parse_category() {};
     virtual void display(int ind) const;
     virtual void write(ostream & o) const {};
     virtual void visit(VisitController * v) const {};
-    static void setWriteController(auto_ptr<WriteController> w);
+    static void setWriteController(unique_ptr<WriteController>& w);
     static WriteController * recoverWriteController();
 };
 
@@ -303,23 +303,25 @@ class symbol_table : public map<string,symbol_class*>
 {
 private:
 	typedef map<string,symbol_class*> _Base;
-	auto_ptr<SymbolFactory<symbol_class> > factory;
+	unique_ptr<SymbolFactory<symbol_class> > factory;
 	
 public :
 
 	symbol_table() : factory(new SymbolFactory<symbol_class>()) {};
+	symbol_table(const symbol_table<VAL::var_symbol>& other) 
+		: factory(new SymbolFactory<symbol_class>(*other.factory)) {};
 
 	void setFactory(SymbolFactory<symbol_class> * sf) 
 	{
-		auto_ptr<SymbolFactory<symbol_class> > x(sf);
-		factory = x;
+		unique_ptr<SymbolFactory<symbol_class> > x(sf);
+		factory = std::move(x);
 	};
 
 	template<class T>
 	void replaceFactory() 
 	{
-		auto_ptr<SymbolFactory<symbol_class> > x(new SpecialistSymbolFactory<symbol_class,T>());
-		factory = x;
+		unique_ptr<SymbolFactory<symbol_class> > x(new SpecialistSymbolFactory<symbol_class,T>());
+		factory = std::move(x);
 	};
 	
     typedef typename _Base::iterator iterator;
@@ -1732,6 +1734,7 @@ public:
 class VarTabFactory {
 public:
 	virtual ~VarTabFactory() {};
+	
 	virtual var_symbol_table * buildPredTab() {return new var_symbol_table;};
 	virtual var_symbol_table * buildFuncTab() {return new var_symbol_table;};
 	virtual var_symbol_table * buildForallTab() {return new var_symbol_table;};
@@ -1764,8 +1767,8 @@ public:
 class analysis
 {
 private:
-	auto_ptr<VarTabFactory> varTabFactory;
-	auto_ptr<StructureFactory> strucFactory;
+	unique_ptr<VarTabFactory> varTabFactory;
+	unique_ptr<StructureFactory> strucFactory;
 	
 public:
 	var_symbol_table * buildPredTab() {return varTabFactory->buildPredTab();};
@@ -1794,14 +1797,14 @@ public:
 
 	void setFactory(VarTabFactory * vf) 
 	{
-		auto_ptr<VarTabFactory> x(vf);
-		varTabFactory = x;
+		unique_ptr<VarTabFactory> x(vf);
+		varTabFactory = std::move(x);
 	};
 
 	void setFactory(StructureFactory * sf)
 	{
-		auto_ptr<StructureFactory> x(sf);
-		strucFactory = x;
+		unique_ptr<StructureFactory> x(sf);
+		strucFactory = std::move(x);
 	};
 
     var_symbol_table_stack var_tab_stack;

--- a/src/popf/FFSolver.cpp
+++ b/src/popf/FFSolver.cpp
@@ -1271,7 +1271,7 @@ void ExtendedMinimalState::deQueueStep(const int & actID, const int & stepID)
     assert(pwItr != pwEnd);
 
 }
-void FF::evaluateStateAndUpdatePlan(auto_ptr<SearchQueueItem> & succ, ExtendedMinimalState & state, ExtendedMinimalState * prevState, set<int> & goals, set<int> & goalFluents, ParentData * const incrementalData, list<ActionSegment> & helpfulActionsExport, const ActionSegment & actID, list<FFEvent> & header)
+void FF::evaluateStateAndUpdatePlan(unique_ptr<SearchQueueItem> & succ, ExtendedMinimalState & state, ExtendedMinimalState * prevState, set<int> & goals, set<int> & goalFluents, ParentData * const incrementalData, list<ActionSegment> & helpfulActionsExport, const ActionSegment & actID, list<FFEvent> & header)
 {
 
     list<ActionSegment> helpfulActions;
@@ -1280,7 +1280,7 @@ void FF::evaluateStateAndUpdatePlan(auto_ptr<SearchQueueItem> & succ, ExtendedMi
     FFEvent extraEvent;
     FFEvent extraEventTwo;
 
-    FFEvent * reusedEndEvent = 0;
+    // FFEvent * reusedEndEvent = nullptr;
 
     bool eventOneDefined = false;
     bool eventTwoDefined = false;
@@ -1340,7 +1340,7 @@ void FF::evaluateStateAndUpdatePlan(auto_ptr<SearchQueueItem> & succ, ExtendedMi
             list<FFEvent>::iterator pwItr = succ->plan.begin();
             for (int sID = 0; sID <= pairWith->stepID; ++sID, ++pwItr) ;
             pwItr->getEffects = true;
-            reusedEndEvent = &(*pwItr);
+            // reusedEndEvent = &(*pwItr);
         }
 
         state.startEventQueue.erase(pairWith);
@@ -3215,7 +3215,7 @@ list<FFEvent> * FF::doBenchmark(bool & reachedGoal, list<FFEvent> * oldSoln, con
             continue;
         }
 
-        auto_ptr<ParentData> pd(LPScheduler::prime(currSQI->plan, currSQI->state()->getInnerState().temporalConstraints,
+        unique_ptr<ParentData> pd(LPScheduler::prime(currSQI->plan, currSQI->state()->getInnerState().temporalConstraints,
                                 currSQI->state()->startEventQueue));
 
         SearchQueueItem * succ = new SearchQueueItem(applyActionToState(actID, *(currSQI->state())), true);
@@ -3278,7 +3278,7 @@ list<FFEvent> * FF::doBenchmark(bool & reachedGoal, list<FFEvent> * oldSoln, con
         FFEvent extraEvent;
         FFEvent extraEventTwo;
 
-        FFEvent * reusedEndEvent = 0;
+        FFEvent * reusedEndEvent = nullptr;
 
         bool eventOneDefined = false;
         bool eventTwoDefined = false;
@@ -3676,7 +3676,7 @@ pair<list<FFEvent>*, TemporalConstraints*> FF::search(bool & reachedGoal)
         searchQueue.push_back(initialSQI, 1);
     }
 
-    auto_ptr<StatesToDelete> statesKept(new StatesToDelete());
+    unique_ptr<StatesToDelete> statesKept(new StatesToDelete());
 
     if (ffDebug) cout << "Initial heuristic = " << bestHeuristic.heuristicValue << "\n";
 
@@ -3690,7 +3690,7 @@ pair<list<FFEvent>*, TemporalConstraints*> FF::search(bool & reachedGoal)
         return pair<list<FFEvent>*, TemporalConstraints*>(new list<FFEvent>(),0);
     }
 
-    auto_ptr<list<FFEvent> > bestPlan(new list<FFEvent>());
+    unique_ptr<list<FFEvent> > bestPlan(new list<FFEvent>());
     {
 
         ExtendedMinimalState * const toHash = new ExtendedMinimalState(initialState);
@@ -3714,7 +3714,7 @@ pair<list<FFEvent>*, TemporalConstraints*> FF::search(bool & reachedGoal)
 
     while (!searchQueue.empty()) {
         if (Globals::globalVerbosity & 2) cout << "\n--\n";
-        auto_ptr<SearchQueueItem> currSQI(searchQueue.pop_front());
+        unique_ptr<SearchQueueItem> currSQI(searchQueue.pop_front());
 
         bool foundBetter = false;
 
@@ -3756,14 +3756,14 @@ pair<list<FFEvent>*, TemporalConstraints*> FF::search(bool & reachedGoal)
         FFheader_upToDate = false;
 
 
-        const auto_ptr<ParentData> incrementalData(LPScheduler::prime(currSQI->plan, currSQI->state()->getInnerState().temporalConstraints,
+        const unique_ptr<ParentData> incrementalData(LPScheduler::prime(currSQI->plan, currSQI->state()->getInnerState().temporalConstraints,
                 currSQI->state()->startEventQueue));
 
 
 
         for (; helpfulActsItr != helpfulActsEnd; ++helpfulActsItr) {
 
-            auto_ptr<SearchQueueItem> succ;
+            unique_ptr<SearchQueueItem> succ;
             bool tsSound = false;
             const int oldTIL = currSQI->state()->getInnerState().nextTIL;
 
@@ -3772,7 +3772,7 @@ pair<list<FFEvent>*, TemporalConstraints*> FF::search(bool & reachedGoal)
                 // TODO: Does this need revisiting?
                 // registerFinished(toSolve->rpg, succ->state, needToFinish);
                 ActionSegment tempSeg(0, VAL::E_AT, oldTIL, RPGHeuristic::emptyIntList);
-                succ = auto_ptr<SearchQueueItem>(new SearchQueueItem(applyActionToState(tempSeg, *(currSQI->state())), true));
+                succ = unique_ptr<SearchQueueItem>(new SearchQueueItem(applyActionToState(tempSeg, *(currSQI->state())), true));
 
                 if (succ->state()) {
                     tsSound = checkTemporalSoundness(*(succ->state()), tempSeg, oldTIL);
@@ -3781,7 +3781,7 @@ pair<list<FFEvent>*, TemporalConstraints*> FF::search(bool & reachedGoal)
                 }
             } else {
                 //registerFinished(*(succ->state), helpfulActsItr->needToFinish);
-                succ = auto_ptr<SearchQueueItem>(new SearchQueueItem(applyActionToState(*helpfulActsItr, *(currSQI->state())), true));
+                succ = unique_ptr<SearchQueueItem>(new SearchQueueItem(applyActionToState(*helpfulActsItr, *(currSQI->state())), true));
                 if (succ->state()) {
                     tsSound = checkTemporalSoundness(*(succ->state()), *helpfulActsItr, oldTIL);
                 } else {
@@ -3792,11 +3792,12 @@ pair<list<FFEvent>*, TemporalConstraints*> FF::search(bool & reachedGoal)
 
 
             if (!tsSound) {
-                if (Globals::globalVerbosity & 1) cout << "t"; cout.flush();
+                if (Globals::globalVerbosity & 1) cout << "t"; 
+                cout.flush();
             } else {
 
 
-                auto_ptr<SearchQueueItem> TILparentAutoDelete(0);
+                unique_ptr<SearchQueueItem> TILparentAutoDelete(nullptr);
                 SearchQueueItem * TILparent = 0;
                 bool TILfailure = false;
                 bool incrementalIsDead = false;
@@ -3849,12 +3850,12 @@ pair<list<FFEvent>*, TemporalConstraints*> FF::search(bool & reachedGoal)
                             }
 
                             TILparent = succ.release();
-                            TILparentAutoDelete = auto_ptr<SearchQueueItem>(TILparent);
+                            TILparentAutoDelete = unique_ptr<SearchQueueItem>(TILparent);
 
 
                             tempSeg = ActionSegment(0, VAL::E_AT, tn, RPGHeuristic::emptyIntList);
 
-                            succ = auto_ptr<SearchQueueItem>(new SearchQueueItem(applyActionToState(tempSeg, *(TILparent->state())), true));
+                            succ = unique_ptr<SearchQueueItem>(new SearchQueueItem(applyActionToState(tempSeg, *(TILparent->state())), true));
 
                             if (!succ->state() || !checkTemporalSoundness(*(succ->state()), tempSeg, tn - 1)) {
                                 succ->heuristicValue.heuristicValue = -1.0;
@@ -3939,7 +3940,8 @@ pair<list<FFEvent>*, TemporalConstraints*> FF::search(bool & reachedGoal)
                                 break;
                             }
                         } else {
-                            if (Globals::globalVerbosity & 1) cout << "."; cout.flush();
+                            if (Globals::globalVerbosity & 1) cout << "."; 
+                            cout.flush();
                             searchQueue.push_back(succ.release(), 1);
                         }
                     } else {
@@ -3955,7 +3957,8 @@ pair<list<FFEvent>*, TemporalConstraints*> FF::search(bool & reachedGoal)
 #endif
                     }
                 } else {
-                    if (Globals::globalVerbosity & 1) cout << "p"; cout.flush();
+                    if (Globals::globalVerbosity & 1) cout << "p"; 
+                    cout.flush();
                 }
             }
         }
@@ -3974,7 +3977,7 @@ pair<list<FFEvent>*, TemporalConstraints*> FF::search(bool & reachedGoal)
 
     WAStar = true;
     visitedStates.clear();
-    statesKept = auto_ptr<StatesToDelete>(new StatesToDelete());
+    statesKept = unique_ptr<StatesToDelete>(new StatesToDelete());
 
     {
 
@@ -4004,7 +4007,7 @@ pair<list<FFEvent>*, TemporalConstraints*> FF::search(bool & reachedGoal)
 
     while (!searchQueue.empty()) {
 
-        auto_ptr<SearchQueueItem> currSQI(searchQueue.pop_front());
+        unique_ptr<SearchQueueItem> currSQI(searchQueue.pop_front());
 
         if (Globals::globalVerbosity & 2) {
             cout << "\n--\n";
@@ -4058,11 +4061,11 @@ pair<list<FFEvent>*, TemporalConstraints*> FF::search(bool & reachedGoal)
         list<ActionSegment >::iterator helpfulActsItr = applicableActions.begin();
         const list<ActionSegment >::iterator helpfulActsEnd = applicableActions.end();
 
-        const auto_ptr<ParentData> incrementalData(LPScheduler::prime(currSQI->plan, currSQI->state()->getInnerState().temporalConstraints,
+        const unique_ptr<ParentData> incrementalData(LPScheduler::prime(currSQI->plan, currSQI->state()->getInnerState().temporalConstraints,
                 currSQI->state()->startEventQueue));
 
         for (; helpfulActsItr != helpfulActsEnd; ++helpfulActsItr) {
-            auto_ptr<SearchQueueItem> succ;
+            unique_ptr<SearchQueueItem> succ;
 
             bool tsSound = false;
             const int oldTIL = currSQI->state()->getInnerState().nextTIL;
@@ -4072,7 +4075,7 @@ pair<list<FFEvent>*, TemporalConstraints*> FF::search(bool & reachedGoal)
             if (helpfulActsItr->second == VAL::E_AT) {
 
                 ActionSegment tempSeg(0, VAL::E_AT, oldTIL, RPGHeuristic::emptyIntList);
-                succ = auto_ptr<SearchQueueItem>(new SearchQueueItem(applyActionToState(tempSeg, *(currSQI->state())), true));
+                succ = unique_ptr<SearchQueueItem>(new SearchQueueItem(applyActionToState(tempSeg, *(currSQI->state())), true));
 
                 if (!succ->state()) {
                     tsSound = false;
@@ -4082,7 +4085,7 @@ pair<list<FFEvent>*, TemporalConstraints*> FF::search(bool & reachedGoal)
             } else {
 
                 //registerFinished(*(succ->state), helpfulActsItr->needToFinish);
-                succ = auto_ptr<SearchQueueItem>(new SearchQueueItem(applyActionToState(*helpfulActsItr, *(currSQI->state())), true));
+                succ = unique_ptr<SearchQueueItem>(new SearchQueueItem(applyActionToState(*helpfulActsItr, *(currSQI->state())), true));
 
                 if (!succ->state()) {
                     tsSound = false;
@@ -4118,7 +4121,7 @@ pair<list<FFEvent>*, TemporalConstraints*> FF::search(bool & reachedGoal)
                     printState(*(succ->state()));
                 }
 
-                auto_ptr<SearchQueueItem> TILparentAutoDelete(0);
+                unique_ptr<SearchQueueItem> TILparentAutoDelete(nullptr);
                 SearchQueueItem * TILparent = 0;
                 bool TILfailure = false;
                 bool incrementalIsDead = false;
@@ -4165,10 +4168,10 @@ pair<list<FFEvent>*, TemporalConstraints*> FF::search(bool & reachedGoal)
                             }
 
                             TILparent = succ.release();
-                            TILparentAutoDelete = auto_ptr<SearchQueueItem>(TILparent);
+                            TILparentAutoDelete = unique_ptr<SearchQueueItem>(TILparent);
 
                             tempSeg = ActionSegment(0, VAL::E_AT, tn, RPGHeuristic::emptyIntList);
-                            succ = auto_ptr<SearchQueueItem>(new SearchQueueItem(applyActionToState(tempSeg, *(TILparent->state())), true));
+                            succ = unique_ptr<SearchQueueItem>(new SearchQueueItem(applyActionToState(tempSeg, *(TILparent->state())), true));
                             if (!succ->state() || !checkTemporalSoundness(*(succ->state()), tempSeg, tn - 1)) {
                                 succ->heuristicValue.heuristicValue = -1.0;
                                 TILfailure = true;
@@ -4488,7 +4491,7 @@ list<FFEvent> * FF::reprocessPlan(list<FFEvent> * oldSoln, TemporalConstraints *
         calculateHeuristicAndSchedule(initialState, 0, goals, numericGoals, (ParentData*) 0, currSQI->helpfulActions, currSQI->plan, tEvent, -1);        
     }
 
-    auto_ptr<StatesToDelete> statesKept(new StatesToDelete());
+    unique_ptr<StatesToDelete> statesKept(new StatesToDelete());
 
     list<FFEvent*>::const_iterator oldSolnItr = sortedSoln.begin();
     const list<FFEvent*>::const_iterator oldSolnEnd = sortedSoln.end();
@@ -4508,11 +4511,11 @@ list<FFEvent> * FF::reprocessPlan(list<FFEvent> * oldSoln, TemporalConstraints *
             scheduleToMetric = true;
         }
         
-        const auto_ptr<ParentData> incrementalData(LPScheduler::prime(currSQI->plan, currSQI->state()->getInnerState().temporalConstraints,
+        const unique_ptr<ParentData> incrementalData(LPScheduler::prime(currSQI->plan, currSQI->state()->getInnerState().temporalConstraints,
                 currSQI->state()->startEventQueue));
 
                 
-        auto_ptr<SearchQueueItem> succ = auto_ptr<SearchQueueItem>(new SearchQueueItem(applyActionToState(nextSeg, *(currSQI->state())), true));
+        unique_ptr<SearchQueueItem> succ = unique_ptr<SearchQueueItem>(new SearchQueueItem(applyActionToState(nextSeg, *(currSQI->state())), true));
         
         evaluateStateAndUpdatePlan(succ,  *(succ->state()), currSQI->state(), goals, numericGoals, incrementalData.get(), succ->helpfulActions, nextSeg, currSQI->plan);
 

--- a/src/popf/FFSolver.h
+++ b/src/popf/FFSolver.h
@@ -436,9 +436,9 @@ private:
 
     static ExtendedMinimalState * applyActionToState(ActionSegment & theAction, const ExtendedMinimalState & parent);
 
-    static void evaluateStateAndUpdatePlan(auto_ptr<SearchQueueItem> & succ, ExtendedMinimalState & state, ExtendedMinimalState * prevState, set<int> & goals, set<int> & goalFluents, ParentData * const incrementalData, list<ActionSegment> & helpfulActionsExport, const ActionSegment & actID, list<FFEvent> & header);
+    static void evaluateStateAndUpdatePlan(unique_ptr<SearchQueueItem> & succ, ExtendedMinimalState & state, ExtendedMinimalState * prevState, set<int> & goals, set<int> & goalFluents, ParentData * const incrementalData, list<ActionSegment> & helpfulActionsExport, const ActionSegment & actID, list<FFEvent> & header);
 
-//  static void justEvaluateNotReuse(auto_ptr<SearchQueueItem> & succ, RPGHeuristic* rpg, ExtendedMinimalState & state, ExtendedMinimalState * prevState, set<int> & goals, set<int> & goalFluents, list<ActionSegment> & helpfulActionsExport, list<FFEvent> & extraEvents, list<FFEvent> & header, HTrio & bestNodeLimitHeuristic, list<FFEvent> *& bestNodeLimitPlan, bool & bestNodeLimitGoal, bool & stagnant, map<double, list<pair<int,int> > > * justApplied, double tilFrom=0.001);
+//  static void justEvaluateNotReuse(unique_ptr<SearchQueueItem> & succ, RPGHeuristic* rpg, ExtendedMinimalState & state, ExtendedMinimalState * prevState, set<int> & goals, set<int> & goalFluents, list<ActionSegment> & helpfulActionsExport, list<FFEvent> & extraEvents, list<FFEvent> & header, HTrio & bestNodeLimitHeuristic, list<FFEvent> *& bestNodeLimitPlan, bool & bestNodeLimitGoal, bool & stagnant, map<double, list<pair<int,int> > > * justApplied, double tilFrom=0.001);
 
 
 //  static bool checkTSTemporalSoundness(RPGHeuristic* const rpg, ExtendedMinimalState & theState, const int & theAction, const VAL::time_spec & ts, const double & incr, int oldTIL=-1);

--- a/src/popf/RPGBuilderEvaluation.cpp
+++ b/src/popf/RPGBuilderEvaluation.cpp
@@ -2856,7 +2856,7 @@ int RPGHeuristic::getRelaxedPlan(const MinimalState & theState, const vector<dou
 
     //rpprintState(theState);
 
-    auto_ptr<Private::BuildingPayload> payload(d->spawnNewPayload(theState, minTimestamps, helpfulActions));
+    unique_ptr<Private::BuildingPayload> payload(d->spawnNewPayload(theState, minTimestamps, helpfulActions));
 
     d->giveUsTheEffectsOfExecutingActions(payload.get());
 


### PR DESCRIPTION
Signed-off-by: Francisco Martin Rico <fmrico@gmail.com>

Hi 

I have changed std::shared_ptr (deprecated) to unique_ptr. This change removes a lot of warnings.

Best