### PR TITLE
CMake: add missing include directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(Clp)
 find_package(CoinUtils)
 find_package(Cbc)
 find_package(Cgl)
+find_package(OSI)
 
 # Some distros/modules don't populate OSI-related variables (e.g. OSICLP_LIBRARIES)
 # but popf's CLP solver needs them when enforcing strict shared-library linking.
@@ -42,6 +43,9 @@ include_directories(
   ${CBC_INCLUDES}/coin  
   ${CPLEX_INCLUDES} 
   ${CONCERT_INCLUDES}
+  ${OSI_INCLUDES}/coin
+  ${COINUTILS_INCLUDES}/coin
+  ${CGL_INCLUDES}/coin
 )
 
 ## ParsePDDL

--- a/src/cmake/modules/FindOSI.cmake
+++ b/src/cmake/modules/FindOSI.cmake
@@ -9,6 +9,7 @@ endif (OSI_INCLUDES AND OSI_LIBRARIES)
 find_path(OSI_INCLUDES
   NAMES
   coin/config_osi.h
+  coin/OsiConfig.h
   PATHS
   ${OSIDIR}/include
   ${INCLUDE_INSTALL_DIR}


### PR DESCRIPTION
Hi,

This PR add some missing include directories to fix:
```cpp
/build/source/src/popf/solver-clp.h:33:10: fatal error: OsiSolverInterface.hpp: No such file or directory
   33 | #include "OsiSolverInterface.hpp"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~
```
```cpp
/nix/store/sz24m3j2r5gic2h7vk6d9mvk6ayqzwzj-osi-0.108.11/include/coin/OsiSolverInterface.hpp:12:10: fatal error: CoinTypes.hpp: No such file or directory
   12 | #include "CoinTypes.hpp"
      |          ^~~~~~~~~~~~~~~
```
and
```cpp
/build/source/src/popf/solver-clp.cpp:30:10: fatal error: CglProbing.hpp: No such file or directory
   30 | #include <CglProbing.hpp>
      |          ^~~~~~~~~~~~~~~~
```